### PR TITLE
Saving headers to the request for easy access

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -11,14 +11,14 @@ const AUTH_TOKEN_HEADER = 'Auth-Token'
 exports.correlationMiddleware = (req, res, next) => {
   const domain = Domain.create()
 
-  const correlationId = res.headers[CORRELATION_ID_HEADER.toLowerCase()]
-  const authToken = res.headers[AUTH_TOKEN_HEADER.toLowerCase()]
+  req.correlationId = res.headers[CORRELATION_ID_HEADER.toLowerCase()]
+  req.authToken = res.headers[AUTH_TOKEN_HEADER.toLowerCase()]
 
   domain.add(req)
   domain.add(res)
 
   domain.run(() => {
-    correlateSession(correlationId, authToken)
+    correlateSession(req.correlationId, req.authToken)
 
     next()
   })


### PR DESCRIPTION
This allows every middleware after this one to easily access this information. This is usefull in places like logging, where the correlationId is needed, or like authentication, where the authToken is needed.