### PR TITLE
Using request headers instead of response headers

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -11,8 +11,8 @@ const AUTH_TOKEN_HEADER = 'Auth-Token'
 exports.correlationMiddleware = (req, res, next) => {
   const domain = Domain.create()
 
-  const correlationId = res.headers[CORRELATION_ID_HEADER.toLowerCase()]
-  const authToken = res.headers[AUTH_TOKEN_HEADER.toLowerCase()]
+  const correlationId = req.headers[CORRELATION_ID_HEADER.toLowerCase()]
+  const authToken = req.headers[AUTH_TOKEN_HEADER.toLowerCase()]
 
   domain.add(req)
   domain.add(res)


### PR DESCRIPTION
If the request from another module contains a correlation Id it shuold be relfected in the current module's logs. Therafore the correlationId should come from the `request` object.